### PR TITLE
Add setting to disable auto refresh game controllers

### DIFF
--- a/XOutput/Resources/Languages/English.json
+++ b/XOutput/Resources/Languages/English.json
@@ -16,6 +16,7 @@
   "DiagnosticsMenu": "Diagnostics",
   "DirectInput": "DirectInput",
   "Disable": "Disable",
+  "DisableAutoRefresh": "Disable automatic device status detection",
   "Edit": "Edit",
   "EmulationStarted": "{0} is emulated as controller #{1}.",
   "EmulationStopped": "{0} is no longer emulated.",

--- a/XOutput/Tools/Settings.cs
+++ b/XOutput/Tools/Settings.cs
@@ -34,6 +34,7 @@ namespace XOutput.Tools
         public bool CloseToTray { get; set; }
         public bool ShowAll { get; set; }
         public bool HidGuardianEnabled { get; set; }
+        public bool DisableAutoRefresh { get; set; }
         public string Language
         {
             get => LanguageManager.Instance.Language;

--- a/XOutput/UI/Windows/MainWindowViewModel.cs
+++ b/XOutput/UI/Windows/MainWindowViewModel.cs
@@ -215,7 +215,6 @@ namespace XOutput.UI.Windows
 
         public void RefreshGameControllers()
         {
-            logger.Debug("REFRESH");
             IEnumerable<SharpDX.DirectInput.DeviceInstance> instances = directInputDevices.GetInputDevices(Model.AllDevices);
 
             bool changed = false;

--- a/XOutput/UI/Windows/MainWindowViewModel.cs
+++ b/XOutput/UI/Windows/MainWindowViewModel.cs
@@ -144,12 +144,9 @@ namespace XOutput.UI.Windows
             Model.Settings = settings;
             RefreshGameControllers();
 
-            if (!settings.DisableAutoRefresh)
-            {
-                timer.Interval = TimeSpan.FromMilliseconds(5000);
-                timer.Tick += (object sender1, EventArgs e1) => { RefreshGameControllers(); };
-                timer.Start();
-            }
+            timer.Interval = TimeSpan.FromMilliseconds(5000);
+            timer.Tick += (object sender1, EventArgs e1) => { if (!settings.DisableAutoRefresh) { RefreshGameControllers(); } };
+            timer.Start();
 
             logger.Debug("Creating keyboard controller");
             Devices.Input.Keyboard.Keyboard keyboard = new Devices.Input.Keyboard.Keyboard();
@@ -218,6 +215,7 @@ namespace XOutput.UI.Windows
 
         public void RefreshGameControllers()
         {
+            logger.Debug("REFRESH");
             IEnumerable<SharpDX.DirectInput.DeviceInstance> instances = directInputDevices.GetInputDevices(Model.AllDevices);
 
             bool changed = false;

--- a/XOutput/UI/Windows/MainWindowViewModel.cs
+++ b/XOutput/UI/Windows/MainWindowViewModel.cs
@@ -40,9 +40,6 @@ namespace XOutput.UI.Windows
         {
             this.dispatcher = dispatcher;
             this.hidGuardianManager = hidGuardianManager;
-            timer.Interval = TimeSpan.FromMilliseconds(5000);
-            timer.Tick += (object sender1, EventArgs e1) => { RefreshGameControllers(); };
-            timer.Start();
         }
 
         public void Dispose()
@@ -146,6 +143,13 @@ namespace XOutput.UI.Windows
             }
             Model.Settings = settings;
             RefreshGameControllers();
+
+            if (!settings.DisableAutoRefresh)
+            {
+                timer.Interval = TimeSpan.FromMilliseconds(5000);
+                timer.Tick += (object sender1, EventArgs e1) => { RefreshGameControllers(); };
+                timer.Start();
+            }
 
             logger.Debug("Creating keyboard controller");
             Devices.Input.Keyboard.Keyboard keyboard = new Devices.Input.Keyboard.Keyboard();

--- a/XOutput/UI/Windows/SettingsModel.cs
+++ b/XOutput/UI/Windows/SettingsModel.cs
@@ -69,6 +69,19 @@ namespace XOutput.UI.Windows
             }
         }
 
+        public bool DisableAutoRefresh
+        {
+            get => settings.DisableAutoRefresh;
+            set
+            {
+                if (settings.DisableAutoRefresh != value)
+                {
+                    settings.DisableAutoRefresh = value;
+                    OnPropertyChanged(nameof(DisableAutoRefresh));
+                }
+            }
+        }
+
         public SettingsModel(RegistryModifier registryModifier, Settings settings)
         {
             this.registryModifier = registryModifier;

--- a/XOutput/UI/Windows/SettingsWindow.xaml
+++ b/XOutput/UI/Windows/SettingsWindow.xaml
@@ -17,6 +17,7 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Label Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Content="{Binding LanguageModel.Data, Converter={StaticResource LanguageConverter}, ConverterParameter='Language'}"/>
         <ComboBox Grid.Column="1" Grid.Row="0" HorizontalAlignment="Left" Width="200" Height="25" ItemsSource="{Binding Model.Languages}" SelectedItem="{Binding Model.SelectedLanguage}"/>
@@ -26,5 +27,7 @@
         <CheckBox Grid.Column="1" Grid.Row="2" HorizontalAlignment="Left" Width="200" VerticalAlignment="Center" IsChecked="{Binding Model.RunAtStartup}"/>
         <Label Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Content="{Binding LanguageModel.Data, Converter={StaticResource LanguageConverter}, ConverterParameter='HidGuardianEnabled'}"/>
         <CheckBox Grid.Column="1" Grid.Row="3" Width="200" VerticalAlignment="Center" IsChecked="{Binding Model.HidGuardianEnabled}"/>
+        <Label Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Content="{Binding LanguageModel.Data, Converter={StaticResource LanguageConverter}, ConverterParameter='DisableAutoRefresh'}"/>
+        <CheckBox Grid.Column="1" Grid.Row="4" Width="200" VerticalAlignment="Center" IsChecked="{Binding Model.DisableAutoRefresh}"/>
     </Grid>
 </Window>


### PR DESCRIPTION
I have been using XOutput for a long time, so first of all thank you for creating it!
I had no problems previously but after a recent Windows update I started having the same problem mentioned in issues:
#208  #194 #170

I tracked down the problem to the dxSharp method directInput.GetDevices(). Everytime this is called, it freezes the mouse for a moment.

I know my change is treating symptom not the cause but this at least made this program usable for me again. 
With this change you need to click the already existing "Force Refresh" button to refresh devices.