### PR TITLE
Add anti-deadzone setting

### DIFF
--- a/XOutput/Devices/Mapper/MapperData.cs
+++ b/XOutput/Devices/Mapper/MapperData.cs
@@ -46,6 +46,10 @@ namespace XOutput.Devices.Mapper
         /// Deadzone
         /// </summary>
         public double Deadzone { get; set; }
+        /// <summary>
+        /// Deadzone
+        /// </summary>
+        public double AntiDeadzone { get; set; }
 
         InputSource source;
 
@@ -56,6 +60,7 @@ namespace XOutput.Devices.Mapper
             MinValue = 0;
             MaxValue = 0;
             Deadzone = 0;
+            AntiDeadzone = 0;
         }
 
         /// <summary>
@@ -73,13 +78,21 @@ namespace XOutput.Devices.Mapper
             }
             else
             {
-                var readvalue = value;
-                if (Math.Abs(value - 0.5) < Deadzone)
+                var readValue = value;
+                
+                if (Math.Abs(readValue - 0.5) < Deadzone)
                 {
-                    readvalue = 0.5;
+                    readValue = 0.5;
                 }
 
-                mappedValue = (readvalue - MinValue) / range;
+                if (AntiDeadzone != 0)
+                {
+                    var sign = readValue < 0.5 ? -1 : 1;
+                    readValue = (((((Math.Abs((readValue - 0.5) * 2)) * (1 - AntiDeadzone)) + AntiDeadzone) * sign) / 2) + 0.5;
+                }
+
+                mappedValue = (readValue - MinValue) / range;
+
                 if (mappedValue < 0)
                 {
                     mappedValue = 0;

--- a/XOutput/Devices/Mapper/MapperData.cs
+++ b/XOutput/Devices/Mapper/MapperData.cs
@@ -88,7 +88,7 @@ namespace XOutput.Devices.Mapper
                 if (AntiDeadzone != 0)
                 {
                     var sign = readValue < 0.5 ? -1 : 1;
-                    readValue = (((((Math.Abs((readValue - 0.5) * 2)) * (1 - AntiDeadzone)) + AntiDeadzone) * sign) / 2) + 0.5;
+                    readValue = (Math.Abs((readValue - 0.5) * 2) * (1 - AntiDeadzone) + AntiDeadzone) * sign / 2 + 0.5;
                 }
 
                 mappedValue = (readValue - MinValue) / range;

--- a/XOutput/Devices/Mapper/MapperData.cs
+++ b/XOutput/Devices/Mapper/MapperData.cs
@@ -47,7 +47,7 @@ namespace XOutput.Devices.Mapper
         /// </summary>
         public double Deadzone { get; set; }
         /// <summary>
-        /// Deadzone
+        /// Anti-Deadzone
         /// </summary>
         public double AntiDeadzone { get; set; }
 

--- a/XOutput/Resources/Languages/Brazilian Portuguese.json
+++ b/XOutput/Resources/Languages/Brazilian Portuguese.json
@@ -13,6 +13,7 @@
   "ControllerDisconnected": "{0} está desconectado.",
   "DPad": "DPad",
   "Deadzone": "Deadzone",
+  "AntiDeadzone": "Anti-Deadzone",
   "DiagnosticsMenu": "Diagnósticos",
   "DirectInput": "DirectInput",
   "Disable": "Desabilitar",

--- a/XOutput/Resources/Languages/English.json
+++ b/XOutput/Resources/Languages/English.json
@@ -13,6 +13,7 @@
   "ControllerDisconnected": "{0} is disconnected.",
   "DPad": "DPad",
   "Deadzone": "Deadzone",
+  "AntiDeadzone": "Anti-Deadzone",
   "DiagnosticsMenu": "Diagnostics",
   "DirectInput": "DirectInput",
   "Disable": "Disable",

--- a/XOutput/Resources/Languages/French.json
+++ b/XOutput/Resources/Languages/French.json
@@ -13,6 +13,7 @@
   "ControllerDisconnected": "{0} est déconnecté.",
   "DPad": "Croix directionnelle",
   "Deadzone": "Zone morte",
+  "AntiDeadzone": "Anti-Zone morte",
   "DiagnosticsMenu": "Diagnostic",
   "DirectInput": "DirectInput",
   "Disable": "Désactiver",

--- a/XOutput/Resources/Languages/German.json
+++ b/XOutput/Resources/Languages/German.json
@@ -13,6 +13,7 @@
   "ControllerDisconnected": "Kontroller {0} wurde getrennt.",
   "DPad": "Steuerkreuz",
   "Deadzone": "Totzonen",
+  "AntiDeadzone": "Anti-Totzonen",
   "DiagnosticsMenu": "Diagnostics",
   "DirectInput": "DirectInput",
   "Disable": "Deaktivieren",

--- a/XOutput/Resources/Languages/Greek.json
+++ b/XOutput/Resources/Languages/Greek.json
@@ -13,6 +13,7 @@
   "ControllerDisconnected": "{0} αποσυνδεδεμένο.",
   "DPad": "DPad",
   "Deadzone": "Νεκρή ζώνη",
+  "AntiDeadzone": "Αντι-Νεκρή ζώνη",
   "DiagnosticsMenu": "Διαγνωστικά",
   "DirectInput": "DirectInput",
   "Disable": "Απενεργοποίηση",

--- a/XOutput/Resources/Languages/Hungarian.json
+++ b/XOutput/Resources/Languages/Hungarian.json
@@ -13,6 +13,7 @@
   "ControllerDisconnected": "{0} eszközről lekapcsolódva.",
   "DPad": "DPad",
   "Deadzone": "Deadzone",
+  "AntiDeadzone": "Anti-Deadzone",
   "DiagnosticsMenu": "Diagnosztika",
   "DirectInput": "DirectInput",
   "Disable": "Kikapcsol",

--- a/XOutput/Resources/Languages/Russian.json
+++ b/XOutput/Resources/Languages/Russian.json
@@ -13,6 +13,7 @@
   "ControllerDisconnected": "Контроллер \"{0}\" отключен.",
   "DPad": "DPad",
   "Deadzone": "Мертвая зона",
+  "AntiDeadzone": "Anti-Мертвая зона",
   "DiagnosticsMenu": "Диагностика",
   "DirectInput": "DirectInput",
   "Disable": "Отключить",

--- a/XOutput/Resources/Languages/Simplified Chinese.json
+++ b/XOutput/Resources/Languages/Simplified Chinese.json
@@ -13,6 +13,7 @@
   "ControllerDisconnected": "{0}已断开连接。",
   "DPad": "DPad",
   "Deadzone": "死角",
+  "AntiDeadzone": "反死区",
   "DiagnosticsMenu": "诊断",
   "DirectInput": "DirectInput",
   "Disable": "禁用",

--- a/XOutput/Resources/Languages/Spanish.json
+++ b/XOutput/Resources/Languages/Spanish.json
@@ -13,6 +13,7 @@
   "ControllerDisconnected": "{0} fue desconectado.",
   "DPad": "DPad",
   "Deadzone": "Zona Muerta",
+  "Deadzone": "Anti-Zona Muerta",
   "DiagnosticsMenu": "Diagnósticos",
   "DirectInput": "DirectInput",
   "Disable": "Desactivado",

--- a/XOutput/UI/Component/MappingModel.cs
+++ b/XOutput/UI/Component/MappingModel.cs
@@ -74,6 +74,19 @@ namespace XOutput.UI
             }
         }
 
+        public decimal? AntiDeadzone
+        {
+            get => (decimal)mapperData.AntiDeadzone * 100;
+            set
+            {
+                if ((decimal)mapperData.AntiDeadzone != value)
+                {
+                    mapperData.AntiDeadzone = (double)(value ?? 100) / 100;
+                    OnPropertyChanged(nameof(AntiDeadzone));
+                }
+            }
+        }
+
         private Visibility configVisibility;
         public Visibility ConfigVisibility
         {

--- a/XOutput/UI/Component/MappingView.xaml
+++ b/XOutput/UI/Component/MappingView.xaml
@@ -30,6 +30,7 @@
                 <ColumnDefinition Width="*" MinWidth="90"/>
                 <ColumnDefinition Width="*" MinWidth="90"/>
                 <ColumnDefinition Width="*" MinWidth="90"/>
+                <ColumnDefinition Width="*" MinWidth="90"/>
             </Grid.ColumnDefinitions>
             <StackPanel Grid.Column="0" Margin="2" Orientation="Horizontal">
                 <TextBlock VerticalAlignment="Center" Text="{Binding LanguageModel.Data, Converter={StaticResource LanguageConverter}, ConverterParameter='Range'}"/>
@@ -45,7 +46,13 @@
                 <local:NumericTextBox VerticalAlignment="Center" Minimum="0" Maximum="50" Value="{Binding Model.Deadzone, Mode=TwoWay}"/>
                 <TextBlock VerticalAlignment="Center" Text="%"/>
             </StackPanel>
-            <Button Grid.Column="2" Margin="2" Click="InvertClick" Content="{Binding LanguageModel.Data, Converter={StaticResource LanguageConverter}, ConverterParameter='Invert'}"/>
+            <StackPanel Grid.Column="2" Margin="2" Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Text="{Binding LanguageModel.Data, Converter={StaticResource LanguageConverter}, ConverterParameter='AntiDeadzone'}"/>
+                <TextBlock VerticalAlignment="Center" Text=": "/>
+                <local:NumericTextBox VerticalAlignment="Center" Minimum="0" Maximum="100" Value="{Binding Model.AntiDeadzone, Mode=TwoWay}"/>
+                <TextBlock VerticalAlignment="Center" Text="%"/>
+            </StackPanel>
+            <Button Grid.Column="3" Margin="2" Click="InvertClick" Content="{Binding LanguageModel.Data, Converter={StaticResource LanguageConverter}, ConverterParameter='Invert'}"/>
         </Grid>
         <Button Grid.Column="3" Margin="2" Click="ConfigureClick" Content="{Binding LanguageModel.Data, Converter={StaticResource LanguageConverter}, ConverterParameter='Configure'}"/>
     </Grid>


### PR DESCRIPTION
This setting is very helpful for games that have a _hardcoded deadzone_, e.g. deadzone settings that cannot be changed by the user.

Suppose the game has 20% deadzone, in which case values between `(0.4, 0.6)` are unavailable. Setting anti-deadzone to 20% will make input of `0.5` correspond to `0.6` and input of `0.49` correspond to `0.4`, effectively negating the deadzone.

## Tested with the following games

 * [Bus Simulator 21](https://store.steampowered.com/app/976590/Bus_Simulator_21/) at 20% anti-deadzone
 * [SnowRunner](https://store.steampowered.com/app/1465360/SnowRunner/) at 30% anti-deadzone

## How this works

 1. the input range is translated from `<0, 1>` to `<-1, 1>`
 2. values between `(-AntiDeadzone, AntiDeadzone)` are cut off
 3. input is evenly distributed among remaining values
 4. input range is translated back to `<0, 1>`

## Related issue

resolves #195
resolves #478

## Credits

Huge thanks to @ricpass for help getting this done 💪 