### PR TITLE
Bug fix: XOutputDevice.RefreshInput() is not thread safe.

### DIFF
--- a/XOutput/Devices/XInput/XOutputDevice.cs
+++ b/XOutput/Devices/XInput/XOutputDevice.cs
@@ -43,7 +43,6 @@ namespace XOutput.Devices.XInput
         private readonly InputMapper mapper;
         private readonly DPadDirection[] dPads = new DPadDirection[DPadCount];
         private readonly XOutputSource[] sources;
-        private readonly DeviceState state;
         private DeviceInputChangedEventArgs deviceInputChangedEventArgs;
 
         /// <summary>
@@ -55,7 +54,6 @@ namespace XOutput.Devices.XInput
         {
             this.mapper = mapper;
             sources = XInputHelper.Instance.GenerateSources();
-            state = new DeviceState(sources, DPadCount);
             deviceInputChangedEventArgs = new DeviceInputChangedEventArgs(this);
         }
 
@@ -108,7 +106,7 @@ namespace XOutput.Devices.XInput
         /// <returns>if the input was available</returns>
         public bool RefreshInput(bool force = false)
         {
-            state.ResetChanges();
+            DeviceState state = new DeviceState(sources, DPadCount);
             foreach (var s in sources)
             {
                 if (s.Refresh(mapper))


### PR DESCRIPTION
Originally observed issue:
* When moving 2 joysticks on 2 different input devices mapped to 1 XOutput device at the same time, occasionally one of the joystick inputs would be lost/disconnect.
* In game, this caused the joystick to remain pressed in some last-polled direction.
* This could be resolved in the XOutput app by hitting the "Force Refresh" button.

Debug/conclusion process:
* Log would show a "WARN Poll failed for ..." when this occurs.
* Log event is from DirectDevice.cs line 319 (`logger.Warning($"Poll failed for {ToString()}");`)
* The exception thrown to cause the log event was a "Collection was modified ..."
* Exception was thrown from line 313 (`InputChanged?.Invoke(this, deviceInputChangedEventArgs);`)
* ...which was invoking `XOutputDevice.SourceInputChange()` which then calls `RefreshInput()`
* Debugging calls in the function, it appeared to be the call to `changes.Any()` that was throwing the exception.
* Looking online for other instances of when such an exception could occur, the quick solution is to make a copy of the Collection for iteration. Adding `ToList()` to line 119 (`changes.GetChanges(force);`) appeared to fix the issue, but is more masking the problem than fixing it.
* How is the Collection being changed? Each `DirectDevice` object that eventually calls into `XOutputDevice.RefreshInput()` has a thread. `RefreshInput()` makes changes to the `state` variable of `XOutputDevice`. It is possible for more than one thread to be calling `RefreshInput()` and thus making asynchronous changes to the `state` variable.
* Excluding it's initialization, `state` is only used/of-use in `RefreshInput()`.
* Solution: Make `state` a local variable of `RefreshInput()`.

This does mean a `DeviceState` is instantiated for each call to `RefreshInput()` which is inefficient.